### PR TITLE
Issue 36 Signupできるようにし、success||errorで対応を分ける

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "whatwg-fetch": "^2.0.3"
   },
   "scripts": {
-    "start": "webpack-dev-server",
+    "start": "webpack-dev-server --history-api-fallback",
     "lint": "prettier-eslint --write src/*"
   },
   "devDependencies": {

--- a/frontend/src/Header.jsx
+++ b/frontend/src/Header.jsx
@@ -19,13 +19,18 @@ const links = [
 
 const buttonStyle = {
   color: 'white',
-  marginTop: 5
-}
+  marginTop: 5,
+};
 
 export class Header extends React.Component {
   render() {
     const linkComponent = links.map(({ path, name }, key) => (
-      <FlatButton label={name} key={key} style={buttonStyle} containerElement={<Link to={path} />} />
+      <FlatButton
+        label={name}
+        key={key}
+        style={buttonStyle}
+        containerElement={<Link to={path} />}
+      />
     ));
 
     return (
@@ -37,11 +42,7 @@ export class Header extends React.Component {
               <ActionHome />
             </IconButton>
           }
-          iconElementRight={
-            <div>
-              {linkComponent}
-            </div>
-          }
+          iconElementRight={<div>{linkComponent}</div>}
         />
       </header>
     );

--- a/frontend/src/UserRegister.jsx
+++ b/frontend/src/UserRegister.jsx
@@ -10,16 +10,15 @@ class UserRegisterForm extends React.Component {
     const name = event.target.name.value;
     const email = event.target.email.value;
     const password = event.target.password.value;
-    console.log(name, email, password);
     if (!name || !email || !password) {
       return;
     }
 
     const form = new FormData();
-    form.append('user[name]', name);
-    form.append('user[email]', email);
-    form.append('user[password]', password);
-    // postForm(form);
+    form.append('name', name);
+    form.append('email', email);
+    form.append('password', password);
+    postForm(form);
 
     // valueを空にする
     ReactDOM.findDOMNode(event.target.name).value = '';
@@ -46,8 +45,7 @@ export class UserRegister extends React.Component {
 }
 
 function postForm(form) {
-  console.log(form);
-  fetch('http://localhost:3000/users', {
+  fetch('http://localhost:3000/v1/auth', {
     header: {
       Accept: 'application/json',
       'Content-Type': 'application/json',

--- a/frontend/src/UserRegister.jsx
+++ b/frontend/src/UserRegister.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { render } from 'react-dom';
+import history from './history';
 import 'whatwg-fetch';
 
 class UserRegisterForm extends React.Component {
@@ -52,5 +53,15 @@ function postForm(form) {
     },
     method: 'POST',
     body: form,
-  });
+  })
+    .then((response) => {
+      if (response.status == 200) {
+        history.push('/');
+      } else {
+        throw Error(response.statusText);
+      }
+    })
+    .catch((error) => {
+      alert('failed to signup');
+    });
 }

--- a/frontend/src/history.jsx
+++ b/frontend/src/history.jsx
@@ -1,0 +1,3 @@
+import createHistroy from 'history/createBrowserHistory';
+
+export default createHistroy();

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import ReactDom from 'react-dom';
-import { BrowserRouter } from 'react-router-dom';
+import { Router } from 'react-router-dom';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import history from './history';
 import { App } from './App';
 
 ReactDom.render(
-  <BrowserRouter>
+  <Router history={history}>
     <MuiThemeProvider>
       <App />
     </MuiThemeProvider>
-  </BrowserRouter>,
+  </Router>,
   document.getElementById('root'),
 );


### PR DESCRIPTION
#36 の件。
frontendでのvalidationは行っていない。（重そうなので、まだ先に回したい）

ded29d4
signupページでリロードすると、エラーで落ちたので、対処
参考リンク：[react-router-redux で URL 直打ちすると Cannot GET /subdir になる](https://qiita.com/diescake/items/904523cb75669dc3c1f3)

da122f2
yarn lint したら、前回の部分も変更されちゃった、見にくくてソーリー
参考リンク：[React + fetch APIでFileをUploadする](https://qiita.com/uryyyyyyy/items/9954205a620b6f3c1f24)