### PR TITLE
#16 ログイン状態を保持し、/subjects/index を叩いたらログインユーザの情報を返すようにする。

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,15 @@ Transfer-Encoding: chunked
 
 ## error
 {"errors":["Invalid login credentials. Please try again."]}
+
+
+# get subjects of an user
+
+## success
+$curl -X GET http://localhost:3000/subjects/index  -H'access-token: Dn-ja2dvqD94sdhn52tEMw' -H'client: drkvJv5bhTwdkvDjqH2CHg' -H'uid: hoge@gmail.com'
+[{"id":1,"user_id":1,"title":"好きな映画ベスト10","created_at":"2017-12-28T00:08:39.257Z","updated_at":"2017-12-28T00:08:39.257Z"},{"id":2,"user_id":1,"title":"嫌いな野菜ベスト5","created_at":"2017-12-28T00:08:39.260Z","updated_at":"2017-12-28T00:08:39.260Z"}]
+
+## error
+$curl -X GET http://localhost:3000/subjects/index
+{"errors":["You need to sign in or sign up before continuing."]}
 ```

--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -1,6 +1,8 @@
 class SubjectsController < ApplicationController
+  before_action :authenticate_v1_user!
+
   def index
-    @subjects = Subject.all
+    @subjects = current_v1_user.subjects
     render json: @subjects
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,9 +6,9 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-Subject.create(user_id: 0, title: "好きな映画ベスト10")
-Subject.create(user_id: 0, title: "嫌いな野菜ベスト5")
-Subject.create(user_id: 1, title: "好きなたこ焼きの店ベスト3")
-
 User.create(name: "hoge", email: "hoge@gmail.com", password: "hogehoge", password_confirmation: "hogehoge")
 User.create(name: "foo", email: "foo@gmail.com", password: "foofoofoo", password_confirmation: "foofoofoo")
+Subject.create(user_id: 1, title: "好きな映画ベスト10")
+Subject.create(user_id: 1, title: "嫌いな野菜ベスト5")
+Subject.create(user_id: 2, title: "好きなたこ焼きの店ベスト3")
+


### PR DESCRIPTION
#16 の対応です。

seed 更新したので、`$ rails db:migrate; rails db:seed` し直すと良い感じになります。

README を見たら分かるように、sign_in したときのレスポンスのヘッダに含まれる情報のうち幾つかをピックアップし、そいつをヘッダに含めた状態で /subjects/index に GET を送ると、そのユーザの subjects が取れます。

参考
ログインするために必要な、リクエストに付与しなきゃならないパラメータって何？
http://clc.gonna.jp/2017/01/post-1306/
それをどうやって送るの？
https://qiita.com/youcune/items/45271a32dccb7498033f