### PR TITLE
#78 route を、/users/#{user_id}/subjects/ 形式にする。

### DIFF
--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -6,6 +6,9 @@ class SubjectsController < ApplicationController
     render json: @subjects
   end
 
+  def show
+  end
+
   def create
     @subject = Subject.new(subject_params)
     @subject.save

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,11 @@
 Rails.application.routes.draw do
-  get 'subjects/index'
-  post 'subjects', to: 'subjects#create'
-
   namespace :v1 do
     mount_devise_token_auth_for 'User',
                                 at: 'auth',
                                 controllers: { registrations: 'v1/auth/registrations' }
+  end
+  resources :users, shallow: true, only: [] do
+    resources :subjects, only: [:index, :show, :create]
   end
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/frontend/src/Subjects.jsx
+++ b/frontend/src/Subjects.jsx
@@ -4,7 +4,7 @@ import history from './history';
 import { render } from 'react-dom';
 import { createSubject } from './common';
 
-const REQUEST_URL = 'http://localhost:3000/subjects/index';
+const REQUEST_URL = `http://localhost:3000/users/${localStorage.getItem('user_id')}/subjects/`;
 
 class SubjectCreateForm extends React.Component {
   handleSubmit(event) {

--- a/frontend/src/Subjects.jsx
+++ b/frontend/src/Subjects.jsx
@@ -3,8 +3,7 @@ import ReactDOM from 'react-dom';
 import history from './history';
 import { render } from 'react-dom';
 import { createSubject } from './common';
-
-const REQUEST_URL = `http://localhost:3000/users/${localStorage.getItem('user_id')}/subjects/`;
+import { getSubject } from './common';
 
 class SubjectCreateForm extends React.Component {
   handleSubmit(event) {
@@ -38,29 +37,8 @@ export class Subjects extends React.Component {
 
   componentDidMount() {
     if (localStorage.getItem('login') === 'true') {
-      this.fetchData();
+      getSubject(this, localStorage.getItem('user_id'));
     }
-  }
-
-  fetchData() {
-    fetch(REQUEST_URL, {
-      headers: {
-        'access-token': localStorage.getItem('access-token'),
-        client: localStorage.getItem('client'),
-        uid: localStorage.getItem('uid'),
-      },
-    }).then((response) => {
-      if (response.status === 200) {
-        response.json().then((responseData) => {
-          this.setState({
-            data: responseData,
-          });
-        });
-      } else {
-        localStorage.setItem('login', 'false');
-        history.push('/login');
-      }
-    });
   }
 
   render() {

--- a/frontend/src/Subjects.jsx
+++ b/frontend/src/Subjects.jsx
@@ -37,6 +37,7 @@ export class Subjects extends React.Component {
 
   componentDidMount() {
     if (localStorage.getItem('login') === 'true') {
+      this.props.onClick(this, localStorage.getItem('user_id'));
       getSubject(this, localStorage.getItem('user_id'));
     }
   }

--- a/frontend/src/Subjects.jsx
+++ b/frontend/src/Subjects.jsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom';
 import history from './history';
 import { render } from 'react-dom';
 import { createSubject } from './common';
-import { getSubject } from './common';
 
 class SubjectCreateForm extends React.Component {
   handleSubmit(event) {

--- a/frontend/src/Subjects.jsx
+++ b/frontend/src/Subjects.jsx
@@ -38,7 +38,6 @@ export class Subjects extends React.Component {
   componentDidMount() {
     if (localStorage.getItem('login') === 'true') {
       this.props.onClick(this, localStorage.getItem('user_id'));
-      getSubject(this, localStorage.getItem('user_id'));
     }
   }
 

--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -5,6 +5,7 @@ import { Subjects } from './Subjects';
 import { Login } from './Login';
 import { Logout } from './Logout';
 import { Signup } from './Signup';
+import { getSubject } from './common';
 
 export class App extends React.Component {
   render() {
@@ -14,7 +15,8 @@ export class App extends React.Component {
           <Header />
         </div>
         <Switch>
-          <Route exact path="/" component={Subjects} />
+          <Route exact path="/"
+            render={props => <Subjects onClick={(_this, user_id) => getSubject(_this, user_id)}/>} />
           <Route path="/login" component={Login} />
           <Route path="/logout" component={Logout} />
           <Route path="/signup" component={Signup} />

--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -15,8 +15,11 @@ export class App extends React.Component {
           <Header />
         </div>
         <Switch>
-          <Route exact path="/"
-            render={props => <Subjects onClick={(_this, user_id) => getSubject(_this, user_id)}/>} />
+          <Route
+            exact
+            path="/"
+            render={props => <Subjects onClick={(_this, user_id) => getSubject(_this, user_id)} />}
+          />
           <Route path="/login" component={Login} />
           <Route path="/logout" component={Logout} />
           <Route path="/signup" component={Signup} />

--- a/frontend/src/common.js
+++ b/frontend/src/common.js
@@ -41,8 +41,8 @@ export function login(email, password) {
         localStorage.setItem('client', response.headers.get('client'));
         localStorage.setItem('uid', response.headers.get('uid'));
         localStorage.setItem('login', 'true');
-        response.json().then(responseJson => {
-          localStorage.setItem('user_id', responseJson.data.id);
+        response.json().then(responseData => {
+          localStorage.setItem('user_id', responseData.data.id);
         });
         history.push('/');
       } else {

--- a/frontend/src/common.js
+++ b/frontend/src/common.js
@@ -41,6 +41,9 @@ export function login(email, password) {
         localStorage.setItem('client', response.headers.get('client'));
         localStorage.setItem('uid', response.headers.get('uid'));
         localStorage.setItem('login', 'true');
+        response.json().then(responseJson => {
+          localStorage.setItem('user_id', responseJson.data.id);
+        });
         history.push('/');
       } else {
         throw Error(response.statusText);

--- a/frontend/src/common.js
+++ b/frontend/src/common.js
@@ -41,7 +41,7 @@ export function login(email, password) {
         localStorage.setItem('client', response.headers.get('client'));
         localStorage.setItem('uid', response.headers.get('uid'));
         localStorage.setItem('login', 'true');
-        response.json().then(responseData => {
+        response.json().then((responseData) => {
           localStorage.setItem('user_id', responseData.data.id);
         });
         history.push('/');
@@ -77,4 +77,25 @@ export function createSubject(title) {
     .catch((error) => {
       alert('failed to create subject');
     });
+}
+
+export function getSubject(_this, user_id) {
+  fetch(`http://localhost:3000/users/${user_id}/subjects/`, {
+    headers: {
+      'access-token': localStorage.getItem('access-token'),
+      client: localStorage.getItem('client'),
+      uid: localStorage.getItem('uid'),
+    },
+  }).then((response) => {
+    if (response.status === 200) {
+      response.json().then((responseData) => {
+        _this.setState({
+          data: responseData,
+        });
+      });
+    } else {
+      localStorage.setItem('login', 'false');
+      history.push('/login');
+    }
+  });
 }

--- a/frontend/src/theme.jsx
+++ b/frontend/src/theme.jsx
@@ -10,4 +10,4 @@ const muiTheme = getMuiTheme({
   },
 });
 
-export default muiTheme
+export default muiTheme;


### PR DESCRIPTION
#78 

* ログイン時にユーザIDを返すようにする。(これは既に実装済みだった)
* それを localStorage に保持するようにする。
* backend 側の routing を変える。
* API呼び出し部分を変える。
* ちょこっとリファクタリングする

ルーティングはこうしました！！！
/subjects/#{subject_id} => subjects#show
/users/#{user_id}/subjects/ => subjects#index

以下に従った。読んでおくべし。
https://railsguides.jp/routing.html#%E3%80%8C%E6%B5%85%E3%81%84%E3%80%8D%E3%83%8D%E3%82%B9%E3%83%88