### PR TITLE
#93 no reload at subjects page

### DIFF
--- a/frontend/src/Subjects.jsx
+++ b/frontend/src/Subjects.jsx
@@ -3,23 +3,27 @@ import ReactDOM from 'react-dom';
 import history from './history';
 import { render } from 'react-dom';
 import { Link } from 'react-router-dom';
-import { createSubject, deleteSubject } from './common';
+import { deleteSubject } from './common';
 
 class SubjectCreateForm extends React.Component {
-  handleSubmit(event) {
+  handleSubmit(event, onClick) {
     event.preventDefault();
     const title = event.target.title.value;
     if (!title) {
       return;
     }
-    createSubject(title, localStorage.getItem('user_id'));
+    onClick(title, localStorage.getItem('user_id'));
 
     ReactDOM.findDOMNode(event.target.title).value = '';
   }
 
   render() {
     return (
-      <form id="subject" className="commentForm" onSubmit={this.handleSubmit}>
+      <form
+        id="subject"
+        className="commentForm"
+        onSubmit={e => this.handleSubmit(e, this.props.onClick)}
+      >
         <input type="text" name="title" placeholder="title" />
         <input type="submit" value="Post" />
       </form>
@@ -30,6 +34,15 @@ class SubjectCreateForm extends React.Component {
 export class Subjects extends React.Component {
   componentDidMount() {
     if (localStorage.getItem('login') === 'true') {
+      this.props.getSubjectsCallback(localStorage.getItem('user_id'));
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (
+      localStorage.getItem('login') === 'true' &&
+      this.props.updateSubjectsToggle !== nextProps.updateSubjectsToggle
+    ) {
       this.props.getSubjectsCallback(localStorage.getItem('user_id'));
     }
   }
@@ -64,7 +77,11 @@ export class Subjects extends React.Component {
                 </tbody>
               ))}
           </table>
-          <SubjectCreateForm />
+          <SubjectCreateForm
+            onClick={(title, user_id) => {
+              this.props.createSubjectCallback(title, user_id);
+            }}
+          />
         </div>
       );
     }

--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -6,13 +6,22 @@ import { Subjects } from './Subjects';
 import { Login } from './Login';
 import { Logout } from './Logout';
 import { Signup } from './Signup';
-import { signup, login, setLogout, getSubjects, getItems } from './common';
+import {
+  signup,
+  login,
+  setLogout,
+  getSubjects,
+  subjectsUpdated,
+  getItems,
+  createSubject,
+} from './common';
 
 export class App extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       subjects: [],
+      updateSubjectsToggle: false,
     };
   }
 
@@ -33,7 +42,11 @@ export class App extends React.Component {
             render={() => (
               <Subjects
                 subjects={this.state.subjects}
+                updateSubjectsToggle={this.state.updateSubjectsToggle}
                 getSubjectsCallback={user_id => getSubjects(this, user_id)}
+                createSubjectCallback={(title, user_id) => {
+                  createSubject(this, title, user_id);
+                }}
               />
             )}
           />

--- a/frontend/src/common.js
+++ b/frontend/src/common.js
@@ -58,7 +58,7 @@ export const setLogout = function () {
   localStorage.setItem('login', 'false');
 };
 
-export function createSubject(title, user_id) {
+export function createSubject(_this, title, user_id) {
   const form = new FormData();
   form.append('title', title);
   form.append('is_public', false);
@@ -73,8 +73,10 @@ export function createSubject(title, user_id) {
     body: form,
   })
     .then((response) => {
-      if (response.status === 204) {
-        location.reload();
+      if (response.status === 200 || response.status === 204) {
+        _this.setState(prev => ({
+          updateSubjectsToggle: !prev.updateSubjectsToggle,
+        }));
       } else {
         throw Error(response.statusText);
       }

--- a/frontend/src/common.js
+++ b/frontend/src/common.js
@@ -15,7 +15,7 @@ export function signup(name, email, password) {
     body: form,
   })
     .then((response) => {
-      if (response.status === 200) {
+      if (response.ok) {
         login(email, password);
       } else {
         throw Error(response.statusText);
@@ -36,7 +36,7 @@ export function login(email, password) {
     body: form,
   })
     .then((response) => {
-      if (response.status === 200) {
+      if (response.ok) {
         localStorage.setItem('access-token', response.headers.get('access-token'));
         localStorage.setItem('client', response.headers.get('client'));
         localStorage.setItem('uid', response.headers.get('uid'));
@@ -73,7 +73,7 @@ export function createSubject(_this, title, user_id) {
     body: form,
   })
     .then((response) => {
-      if (response.status === 200 || response.status === 204) {
+      if (response.ok) {
         _this.setState(prev => ({
           updateSubjectsToggle: !prev.updateSubjectsToggle,
         }));
@@ -94,7 +94,7 @@ export function getSubjects(_this, user_id) {
       uid: localStorage.getItem('uid'),
     },
   }).then((response) => {
-    if (response.status === 200) {
+    if (response.ok) {
       response.json().then((responseData) => {
         _this.setState({
           subjects: responseData,
@@ -117,7 +117,7 @@ export function deleteSubject(subject_id) {
     method: 'DELETE',
   })
     .then((response) => {
-      if (response.status === 204) {
+      if (response.ok) {
         location.reload();
       } else {
         throw Error(response.statusText);
@@ -142,7 +142,7 @@ export function createItem(name, subject_id) {
     body: form,
   })
     .then((response) => {
-      if (response.status === 204) {
+      if (response.ok) {
         location.reload();
       } else {
         throw Error(response.statusText);
@@ -161,7 +161,7 @@ export function getItems(_this, subject_id) {
       uid: localStorage.getItem('uid'),
     },
   }).then((response) => {
-    if (response.status === 200) {
+    if (response.ok) {
       response.json().then((responseData) => {
         _this.setState({
           items: responseData,


### PR DESCRIPTION
#93 の対応

ひとまず subjects ページのみの対応とさせてください。
これでOKが出てマージされたら、items の方の修正も行います(#106)。

# 技術的変更点
- createSubject() を props で渡すようにした。
- createSubject() が走るたびにstate に持たせるフラグを切り替えるようにした。
- state が変わると componentWillReceiveProps() というライフサイクルメソッドが走るので、そこでフラグをチェックして、変更されそうならば getSubjects() を実行するようにした。