### PR TITLE
#91 Signup時に空文字を弾くvalidationをFEに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 .byebug_history
 
 frontend/node_modules/
+.env

--- a/frontend/src/Signup.jsx
+++ b/frontend/src/Signup.jsx
@@ -17,7 +17,9 @@ class SignupForm extends React.Component {
 
   onTextFieldChange(event) {
     if (event.target.value) {
-      eval("this.setState({" + event.target.name + "ErrorText: '', })");
+      this.setState({
+        [event.target.name + "ErrorText"]: "",
+      });
     }
   }
 

--- a/frontend/src/Signup.jsx
+++ b/frontend/src/Signup.jsx
@@ -23,20 +23,17 @@ class SignupForm extends React.Component {
 
   validate(name, email, password) {
     const field = ["name", "email", "password"];
-    let validationError = false
+    let isValid = true
     for (let f of field) {
       if (!eval(f)) {
         eval("this.setState({" + f + "ErrorText: f + ' is invalid', })");
-        validationError = true;
+        isValid = false;
       } else {
         eval("this.setState({" + f + "ErrorText: '', })");
       }
     }
 
-    if (validationError) {
-      return true
-    }
-    return false
+    return isValid;
   }
 
   handleSubmit(event, onClick) {
@@ -45,7 +42,7 @@ class SignupForm extends React.Component {
     const name = event.target.name.value;
     const email = event.target.email.value;
     const password = event.target.password.value;
-    if(this.validate(name, email, password)) {
+    if(!this.validate(name, email, password)) {
       return;
     }
     onClick(name, email, password);

--- a/frontend/src/Signup.jsx
+++ b/frontend/src/Signup.jsx
@@ -26,7 +26,6 @@ class SignupForm extends React.Component {
   validate(items) {
     let isValid = true
     for (let item in items) {
-      // 空白チェック
       if (!items[item]) {
         this.setState({
           [item + "ErrorText"]: `${item} is invalid`,

--- a/frontend/src/Signup.jsx
+++ b/frontend/src/Signup.jsx
@@ -1,17 +1,51 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { render } from 'react-dom';
+import TextField from 'material-ui/TextField';
 import 'whatwg-fetch';
 import { signup } from './common';
 
 class SignupForm extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      nameErrorText: '',
+      emailErrorText: '',
+      passwordErrorText: '',
+    };
+  }
+
+  onTextFieldChange(event) {
+    if (event.target.value) {
+      eval("this.setState({" + event.target.name + "ErrorText: '', })");
+    }
+  }
+
+  validate(name, email, password) {
+    const field = ["name", "email", "password"];
+    let validationError = false
+    for (let f of field) {
+      if (!eval(f)) {
+        eval("this.setState({" + f + "ErrorText: f + ' is invalid', })");
+        validationError = true;
+      } else {
+        eval("this.setState({" + f + "ErrorText: '', })");
+      }
+    }
+
+    if (validationError) {
+      return true
+    }
+    return false
+  }
+
   handleSubmit(event, onClick) {
     // ボタンを押すことによる遷移を抑制
     event.preventDefault();
     const name = event.target.name.value;
     const email = event.target.email.value;
     const password = event.target.password.value;
-    if (!name || !email || !password) {
+    if(this.validate(name, email, password)) {
       return;
     }
     onClick(name, email, password);
@@ -29,9 +63,27 @@ class SignupForm extends React.Component {
         className="commentForm"
         onSubmit={event => this.handleSubmit(event, this.props.onClick)}
       >
-        <input type="text" name="name" placeholder="name" />
-        <input type="text" name="email" placeholder="email" />
-        <input type="text" name="password" placeholder="password" />
+        <TextField
+          name="name"
+          placeholder="name"
+          errorText={this.state.nameErrorText}
+          onChange={this.onTextFieldChange.bind(this)}
+        />
+        <br />
+        <TextField
+          name="email"
+          placeholder="email"
+          errorText={this.state.emailErrorText}
+          onChange={this.onTextFieldChange.bind(this)}
+        />
+        <br />
+        <TextField
+          name="password"
+          placeholder="password"
+          errorText={this.state.passwordErrorText}
+          onChange={this.onTextFieldChange.bind(this)}
+        />
+        <br />
         <input type="submit" value="Post" />
       </form>
     );

--- a/frontend/src/Signup.jsx
+++ b/frontend/src/Signup.jsx
@@ -21,15 +21,19 @@ class SignupForm extends React.Component {
     }
   }
 
-  validate(name, email, password) {
-    const field = ["name", "email", "password"];
+  validate(items) {
     let isValid = true
-    for (let f of field) {
-      if (!eval(f)) {
-        eval("this.setState({" + f + "ErrorText: f + ' is invalid', })");
+    for (let item in items) {
+      // 空白チェック
+      if (!items[item]) {
+        this.setState({
+          [item + "ErrorText"]: `${item} is invalid`,
+        });
         isValid = false;
       } else {
-        eval("this.setState({" + f + "ErrorText: '', })");
+        this.setState({
+          [item + "ErrorText"]: "",
+        });
       }
     }
 
@@ -42,7 +46,7 @@ class SignupForm extends React.Component {
     const name = event.target.name.value;
     const email = event.target.email.value;
     const password = event.target.password.value;
-    if(!this.validate(name, email, password)) {
+    if(!this.validate({name, email, password})) {
       return;
     }
     onClick(name, email, password);


### PR DESCRIPTION
#91 をFEで実装する場合ということで、思い浮かんだやつを実装しました。

・空文字を弾くvalidationだけ実装
・stateを持たない方法を思いつかなかった
・format checkとかは、validate()の中に書くか、関数作っちゃうかで拡張するイメージ

@longtime1116 レビューお願いしますー

参考リンク：http://www.material-ui.com/#/components/text-field